### PR TITLE
Lamp connector description id & sofa particle fix

### DIFF
--- a/common/src/main/java/com/starfish_studios/another_furniture/block/LampConnectorBlock.java
+++ b/common/src/main/java/com/starfish_studios/another_furniture/block/LampConnectorBlock.java
@@ -121,4 +121,10 @@ public class LampConnectorBlock extends Block implements SimpleWaterloggedBlock 
             case BLACK -> AFBlocks.BLACK_LAMP.get();
         };
     }
+
+    @Override
+    public String getDescriptionId() {
+        Block lamp = getLampByColor(color);
+        return lamp.getDescriptionId();
+    }
 }

--- a/common/src/main/resources/assets/another_furniture/models/block/template/sofa_inner.json
+++ b/common/src/main/resources/assets/another_furniture/models/block/template/sofa_inner.json
@@ -4,11 +4,11 @@
 		"wood_1": "another_furniture:block/sofa/wood_1",
 		"wood_2": "another_furniture:block/sofa/wood_2",
 		"bottom": "another_furniture:block/sofa/bottom_inner",
-		"particle": "another_furniture:block/sofa/white_seat_inner",
 		"seat_top": "another_furniture:block/sofa/white_seat_inner",
 		"seat_front": "another_furniture:block/sofa/white_seat_front",
 		"seat_back_2": "another_furniture:block/sofa/white_seat_back_2",
-		"back": "another_furniture:block/sofa/white_back"
+		"back": "another_furniture:block/sofa/white_back",
+		"particle": "#seat_top"
 	},
 	"elements": [
 		{


### PR DESCRIPTION
This addresses two small issues I found while creating an addon:
1) the particle texture for inner sofa parts always uses the white sofa texture and is not overridden by the colored ones
2) lamp connector blocks don't have a translations and show their translation key when using a mod like Jade or TOP, now they show the translation of their corresponding lamp